### PR TITLE
Update oscilloscope sample controls

### DIFF
--- a/src/assets/js/wflDictionary.js
+++ b/src/assets/js/wflDictionary.js
@@ -399,8 +399,14 @@ var waveformsLiveDictionary = (function() {
         oscSamplingFreq: {
             english: 'Osc Sampling Frequency'
         },
+        oscSampleFreqLocked: {
+            english: 'Lock Sampling Frequency to Timebase'
+        },
         oscSampleSize: {
             english: 'Osc Sample Size'
+        },
+        oscSampleSizeLocked: {
+            english: 'Lock Sample Size'
         },
         xAxisTpd: {
             english: 'Set Time / Division'

--- a/src/assets/js/wflDictionary.js
+++ b/src/assets/js/wflDictionary.js
@@ -400,13 +400,13 @@ var waveformsLiveDictionary = (function() {
             english: 'Osc Sampling Frequency'
         },
         oscSampleFreqLocked: {
-            english: 'Lock Sampling Frequency to Timebase'
+            english: 'Lock sampling frequency to timebase'
         },
         oscSampleSize: {
             english: 'Osc Sample Size'
         },
         oscSampleSizeLocked: {
-            english: 'Lock Sample Size'
+            english: 'Lock sample size'
         },
         xAxisTpd: {
             english: 'Set Time / Division'

--- a/src/components/yaxis-controls/yaxis-controls.html
+++ b/src/components/yaxis-controls/yaxis-controls.html
@@ -68,17 +68,15 @@
                 </ion-row>
                 
                 <ion-row class="controls-container">
-                    <ion-col center class="vpd-label-col" [tooltip]="tooltipService.getTooltip('oscSamplingFreq').message" [tooltipAnimation]="true" tooltipPlacement="top">
-                        Samples/
+                    <ion-col center class="vpd-label-col">
+                        Sample Rate
                     </ion-col>
-                    <ion-col text-right center class="vpd-button-col">
-                    </ion-col>
-                    <ion-col class="samplefreq-val-col" center text-center>
+                    <ion-col class="samplefreq-val-col" center text-center [tooltip]="tooltipService.getTooltip('oscSamplingFreq').message" [tooltipAnimation]="true" tooltipPlacement="top">
                         <input [disabled]="lockedSampleState[i].sampleFreqLocked" class="custom-input" step="any" 
                             [ngModel]="(lockedSampleState[i].sampleFreqLocked ? chart.calculateDataFromWindow().sampleFreq : lockedSampleState[i].manualSampleFreq) | unitFormat:'S/s'" 
                             formatInput (valChange)="formatInputAndUpdate($event, i, 'sampleFreq')" />
                     </ion-col>
-                    <ion-col text-left center class="vpd-button-col margin-right"> 
+                    <ion-col text-left center class="vpd-button-col margin-right" [tooltip]="tooltipService.getTooltip('oscSampleFreqLocked').message" [tooltipAnimation]="true" tooltipPlacement="left"> 
                         <button ion-button (tap)="toggleSampleFreqLock(i)" class="icon-only-button-side disable-hover offset-button">
                             <img class="button-side-svg" [src]="lockedSampleState[i].sampleFreqLocked ? 'assets/img/close-lock.svg' : 'assets/img/open-lock.svg'">
                         </button>
@@ -86,17 +84,15 @@
                 </ion-row>
                 
                 <ion-row class="controls-container">
-                    <ion-col center class="vpd-label-col" [tooltip]="tooltipService.getTooltip('oscSampleSize').message" [tooltipAnimation]="true" tooltipPlacement="top">
-                        Samples
+                    <ion-col center class="vpd-label-col">
+                        Sample Size
                     </ion-col>
-                    <ion-col text-right center class="vpd-button-col">
-                    </ion-col>
-                    <ion-col class="samplefreq-val-col" center text-center>
+                    <ion-col class="samplefreq-val-col" center text-center [tooltip]="tooltipService.getTooltip('oscSampleSize').message" [tooltipAnimation]="true" tooltipPlacement="top">
                         <input [disabled]="lockedSampleState[i].sampleSizeLocked" class="custom-input" step="any" 
                             [ngModel]="(lockedSampleState[i].sampleSizeLocked ? chart.calculateDataFromWindow().bufferSize : lockedSampleState[i].manualSampleSize) | unitFormat:'S'"
                             formatInput (valChange)="formatInputAndUpdate($event, i, 'numSamples')" />
                     </ion-col>
-                    <ion-col text-left center class="vpd-button-col margin-right">
+                    <ion-col text-left center class="vpd-button-col margin-right" [tooltip]="tooltipService.getTooltip('oscSampleSizeLocked').message" [tooltipAnimation]="true" tooltipPlacement="left">
                         <button ion-button (tap)="toggleSampleLock(i)" class="icon-only-button-side disable-hover offset-button">
                             <img class="button-side-svg" [src]="lockedSampleState[i].sampleSizeLocked ? 'assets/img/close-lock.svg' : 'assets/img/open-lock.svg'">
                         </button>

--- a/src/components/yaxis-controls/yaxis-controls.scss
+++ b/src/components/yaxis-controls/yaxis-controls.scss
@@ -184,7 +184,7 @@ ion-navbar
 
 .yaxis-component-container .samplefreq-val-col
 {
-    min-width: 80px;
+    max-width: 87px;
     padding: 0px 4px 0px 4px;
 }
 


### PR DESCRIPTION
## Update the oscilloscope sampling controls:

- Old label for sample rate said `Samples/` (samples per division) which is not correct, this should be `Sample Rate` or `Sample Frequency`, changed to `Sample Rate` for clarity.
- Changed label for sample size from `Samples` to `Sample Size` for clarity.
- Add tooltips to the sample rate and sample size lock buttons explaining what they do.

Thanks! Let me know if you have any suggestions for the tooltip text for the `Sample Rate` lock button, I think what I have now is fairly clear but I'm sure there might be a better way of explaining it...

##### Before:
![screen shot 2018-08-12 at 8 09 29 pm](https://user-images.githubusercontent.com/170317/44008085-5109fa6e-9e6d-11e8-848d-d15f47863d95.png)

##### After:
![screen shot 2018-08-12 at 8 20 54 pm](https://user-images.githubusercontent.com/170317/44008087-5a3894ec-9e6d-11e8-98bb-6d19984c556f.png)

![screen shot 2018-08-12 at 8 22 14 pm](https://user-images.githubusercontent.com/170317/44008098-7d411ce8-9e6d-11e8-9261-b997b91190fd.png)

![screen shot 2018-08-12 at 8 22 30 pm](https://user-images.githubusercontent.com/170317/44008100-81ad547c-9e6d-11e8-9ad5-b2a1bbcb1f64.png)

